### PR TITLE
[공통 헤더] 장바구니 관련 헤더 기능 구현

### DIFF
--- a/src/@store/cartListState.js
+++ b/src/@store/cartListState.js
@@ -10,6 +10,12 @@ export const cartListState = atom({
   effects_UNSTABLE: [persistAtom],
 });
 
+export const lastAddProductState = atom({
+  key: 'lastAddProductState',
+  default: {},
+  effects_UNSTABLE: [persistAtom],
+});
+
 //selector
 // 상품 선택관련 셀렉터
 export const filterType = selector({
@@ -135,4 +141,28 @@ export const plusStock = selector({
   },
 });
 
-//상품 삭제 관련 셀렉터
+//이미 존재하는 상품 담기 관련 셀렉터
+export const addExistProduct = selector({
+  key: 'addExistProduct',
+  get: ({ get }) => {
+    return;
+  },
+  set: ({ get, set }, newValue) => {
+    const cartList = get(cartListState);
+    set(
+      cartListState,
+      cartList.map((product) => {
+        if (product.title === newValue[0]) {
+          console.log(typeof product.stock, typeof newValue[1]);
+          return {
+            ...product,
+            stock: Number(product.stock + newValue[1]),
+          };
+        } else {
+          return { ...product };
+        }
+        return cartList;
+      })
+    );
+  },
+});

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
 import styles from './Header.module.css';
@@ -15,11 +15,28 @@ import { ScrollNav } from './ScrollNav/ScrollNav';
 import { NormalNav } from './NormalNav/NormalNav';
 import { throttle } from '../../utils/throttle';
 import CartAddedModal from '../ProductDetail/ProductDetailItem/CartAddedModal/CartAddedModal';
+import { useRecoilState } from 'recoil';
+import { cartListState, lastAddProductState } from '../../@store/cartListState';
+import { useDidMountEffect } from '@/custom/useDidMountEffect';
 const Header = (props) => {
+  const [cartList, setCartList] = useRecoilState(cartListState);
+  const [lastProduct, setLastProduct] = useRecoilState(lastAddProductState);
+  const didMount = useRef(false);
+
+  const [isShow, setIsShow] = useState(false);
+
+  const [isScrolled, setIsScrolled] = useState(false);
+
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  const [isScrolled, setIsScrolled] = useState(false);
+  const toggleShow = () => {
+    setIsShow(true);
+    setTimeout(() => {
+      setIsShow(false);
+    }, 2000);
+  };
+  useDidMountEffect(toggleShow, [lastProduct]);
 
   const handleScroll = throttle(() => {
     if (window.scrollY > document.querySelector('header').offsetHeight - 60) {
@@ -27,7 +44,8 @@ const Header = (props) => {
     } else {
       setIsScrolled(false);
     }
-  }, 40);
+  }, 20);
+
   useEffect(() => {
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
@@ -99,11 +117,14 @@ const Header = (props) => {
               <Link to="/cart">
                 <img src={cart} alt="장바구니" width="36" height="36" />
               </Link>
-              <CartAddedModal />
+              {cartList.length !== 0 && (
+                <span className={styles['cart-number']}>{cartList.length}</span>
+              )}
+              {isShow && <CartAddedModal />}
             </div>
           </div>
         </section>
-        {isScrolled ? <ScrollNav /> : <NormalNav />}
+        {isScrolled ? <ScrollNav isShow={isShow} /> : <NormalNav />}
       </div>
     </header>
   );

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -17,7 +17,7 @@ import { throttle } from '../../utils/throttle';
 import CartAddedModal from '../ProductDetail/ProductDetailItem/CartAddedModal/CartAddedModal';
 import { useRecoilState } from 'recoil';
 import { cartListState, lastAddProductState } from '../../@store/cartListState';
-import { useDidMountEffect } from '@/custom/useDidMountEffect';
+import { useDidMountEffect } from '@/hooks/useDidMountEffect';
 const Header = (props) => {
   const [cartList, setCartList] = useRecoilState(cartListState);
   const [lastProduct, setLastProduct] = useRecoilState(lastAddProductState);

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -153,3 +153,20 @@ a {
   opacity: 0.8;
   font-size: var(--text-base);
 }
+
+.cart-box .cart-number {
+  position: absolute;
+  right: -4px;
+  top: -1px;
+  width: 20px;
+  height: 20px;
+  padding: 0px 5px;
+  border: 2px solid rgb(255, 255, 255);
+  border-radius: 10px;
+  background-color: rgb(95, 0, 128);
+  font-size: 9px;
+  color: rgb(255, 255, 255);
+  line-height: 15px;
+  text-align: center;
+  white-space: nowrap;
+}

--- a/src/components/Header/ScrollNav/ScrollNav.jsx
+++ b/src/components/Header/ScrollNav/ScrollNav.jsx
@@ -6,8 +6,12 @@ import heart from '@/assets/header/heart.png';
 import cart from '@/assets/header/cart.png';
 import { Link } from 'react-router-dom';
 import { Category } from '../Category/Category';
+import { useRecoilValue, useRecoilState } from 'recoil';
+import { cartListState } from '../../../@store/cartListState';
+import CartAddedModal from '../../ProductDetail/ProductDetailItem/CartAddedModal/CartAddedModal';
 
-function ScrollNav(props) {
+function ScrollNav({ isShow }) {
+  const [cartList, setCartList] = useRecoilState(cartListState);
   return (
     <nav className={styles['scroll-header-container']}>
       <div className={styles.wrapper}>
@@ -60,7 +64,7 @@ function ScrollNav(props) {
               <img src={heart} alt="찜" width="36" height="36" />
             </span>
           </li>
-          <li>
+          <li className={styles.cart}>
             <Link to="/cart">
               <img
                 src={cart}
@@ -69,8 +73,10 @@ function ScrollNav(props) {
                 height="36"
               />
             </Link>
-            {/* <span className="cart-number">1</span> */}
-            {/* <div className="cart-alarm is-not-exist"></div> */}
+            {cartList.length !== 0 && (
+              <span className={styles['cart-number']}>{cartList.length}</span>
+            )}
+            {isShow && <CartAddedModal />}
           </li>
         </ul>
       </div>

--- a/src/components/Header/ScrollNav/ScrollNav.module.css
+++ b/src/components/Header/ScrollNav/ScrollNav.module.css
@@ -81,3 +81,23 @@ legend {
 .heart {
   margin: 0 var(--spacing-md);
 }
+
+.cart {
+  position: relative;
+}
+.cart-number {
+  position: absolute;
+  right: -4px;
+  top: -1px;
+  width: 20px;
+  height: 20px;
+  padding: 0px 5px;
+  border: 2px solid rgb(255, 255, 255);
+  border-radius: 10px;
+  background-color: rgb(95, 0, 128);
+  font-size: 9px;
+  color: rgb(255, 255, 255);
+  line-height: 15px;
+  text-align: center;
+  white-space: nowrap;
+}

--- a/src/components/ProductDetail/ProductDetailItem/CartAddedModal/CartAddedModal.jsx
+++ b/src/components/ProductDetail/ProductDetailItem/CartAddedModal/CartAddedModal.jsx
@@ -1,13 +1,27 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './CartAddedModal.module.css';
+import { useRecoilState } from 'recoil';
+import {
+  cartListState,
+  lastAddProductState,
+} from '../../../../@store/cartListState';
 
 function CartAddedModal(props) {
+  const [cartList, setCartList] = useRecoilState(cartListState);
+  const [lastProduct, setLastProduct] = useRecoilState(lastAddProductState);
+
   return (
     <>
       <div className={styles.container}>
-        <img src="" alt="" width="46" height="60" className={styles.image} />
+        <img
+          src={lastProduct.src}
+          alt={lastProduct.alt}
+          width="46"
+          height="60"
+          className={styles.image}
+        />
         <div className={styles['text-wrapper']}>
-          <h2 className={styles.title}>상품이름</h2>
+          <h2 className={styles.title}>{lastProduct.title}</h2>
           <p className={styles.content}>장바구니에 상품을 담았습니다.</p>
         </div>
       </div>

--- a/src/components/ProductDetail/ProductDetailItem/CartAddedModal/CartAddedModal.module.css
+++ b/src/components/ProductDetail/ProductDetailItem/CartAddedModal/CartAddedModal.module.css
@@ -2,6 +2,7 @@
 @import url('@/components/ProductDetail/reset.css');
 
 .container {
+  transition: all 0.3s ease;
   background-color: var(--white);
   width: 254px;
   position: absolute;
@@ -59,9 +60,13 @@
 }
 
 .title {
+  width: 144px;
   font-size: 12px;
   font-weight: bold;
   color: #999;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .content {

--- a/src/hooks/useDidMountEffect.js
+++ b/src/hooks/useDidMountEffect.js
@@ -1,0 +1,10 @@
+import { useEffect, useRef } from 'react';
+
+export const useDidMountEffect = (func, deps) => {
+  const didMount = useRef(false);
+
+  useEffect(() => {
+    if (didMount.current) func();
+    else didMount.current = true;
+  }, deps);
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,7 @@ import App from './App';
 import './css/index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+  <>
     <App />
-  </React.StrictMode>
+  </>
 );


### PR DESCRIPTION
## 작업사항
### 장바구니 담기 관련 기능
#### 장바구니에 상품을 담으면 헤더 장바구니 아이콘 옆 숫자 증가, 삭제하면 감소
#### 장바구니에 상품 담을 때 헤더에 담은 상품에 대한 알림창 띄우기
   - 마지막에 담긴 상품을 관리할 상태 atom 생성 
   - useEffect의 특성상 처음 렌더링될 때 장바구니 알림창이 띄워지는 것을 막기 위해 useDidMountEffect 커스텀 훅 생성 

## 그 외 참고 사항 
- main.jsx React.StrictMode 제거 
- 헤더 스크롤 이벤트 쓰로틀 40->20 수정 
<br/>